### PR TITLE
chore(renovate): add default label

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": ["dependencies"],
   "extends": [
     "config:recommended"
   ]


### PR DESCRIPTION
This adds the [`dependencies`](https://github.com/CFenner/PyViCare/labels/dependencies) label to all PRs created by renovate.